### PR TITLE
Don't lap timer is not running

### DIFF
--- a/static/stopwatch.js
+++ b/static/stopwatch.js
@@ -22,6 +22,7 @@ var _createClass = function () { function defineProperties(target, props) { for 
         }
     }, {
         key: 'lap', value: function lap() {
+            if (!this.running) return;
             var times = this.times;
             var li = document.createElement('li');
             li.innerText = this.format(times);


### PR DESCRIPTION
This PR fixes a bug in timing controls that creates a new lap even when the timer is not running. 