### PR TITLE
Add a GitHub Action to deploy to GitHub Pages

### DIFF
--- a/.github/workflows/deploy_to_gh_pages.yml
+++ b/.github/workflows/deploy_to_gh_pages.yml
@@ -1,0 +1,21 @@
+name: Deploy Wheel of Misfortune to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          pushd incidents/
+          ls | while read i; do cp $i ${i/.sample/}; done
+          popd
+      - uses: crazy-max/ghaction-github-pages@v2
+        with:
+          build_dir: .
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Since the files are moved to have the .sample suffix, we need to rename
them before deploying. This PR adds a GitHub action that performs the
rename of the configs and then the deploy.