### PR TITLE
Reset UI when restarting and spinning wheel

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,7 +146,7 @@
                     <div class="stopwatch pa3"></div>
                     <button id="start" class="button" onClick="stopwatch.start();changeControls();">▶</button>
                     <button id="restart" class="button"
-                        onClick="stopwatch.restart();stopwatch.clear();changeControls();">↻</button>
+                        onClick="restart();">↻</button>
                     <button id="lap" class="button" onClick="stopwatch.lap();">Lap</button>
                     <ul class="results"></ul>
                     <script src="static/stopwatch.js"></script>
@@ -165,6 +165,30 @@
 </html>
 
 <script>
+
+    function restart() {
+        changeControls();
+        var timingBtn = document.getElementById("start");
+        if (!timingBtn) {
+            var timingBtn = document.getElementById("stop");
+        }
+        timingBtn.setAttribute('onclick', 'stopwatch.stop();changeControls();');
+        timingBtn.id = "stop";
+        timingBtn.innerText = "||";
+
+        stopwatch.restart();
+        stopwatch.clear();
+        
+        document.getElementById("first").checked = false;
+        document.getElementById("second").checked = false;
+        document.getElementById("third").checked = false;
+        document.getElementById("fourth").checked = false;
+
+        document.getElementById("first").disabled = false;
+        document.getElementById("second").disabled = true;
+        document.getElementById("third").disabled = true;
+        document.getElementById("fourth").disabled = true;
+    }
 
     function unlockCheckbox(c) {
         if (c.value == "first") {
@@ -211,7 +235,5 @@
             timingBtn.id = "start";
             timingBtn.innerText = "▶";
         }
-
-
     }
 </script>

--- a/static/wheel.js
+++ b/static/wheel.js
@@ -1,7 +1,7 @@
 /* This is a modified version of Jeremy Rue's Wheel of Fortune
  * http://bl.ocks.org/jrue/a2aaf36b3c096925ccbf */
 
-function custom_colors(n) {
+ function custom_colors(n) {
     var colors = ["#388E3C", "#1976D2", "#D32F2F", "#FFA000", "#388E3C", "#990099", "#0099c6", "#C2185B", "#81C784", "#D32F2F", "#1976D2", "#994499", "#4DD0E1", "#AED581", "#536DFE", "#FBC02D", "#C62828", "#AB47BC", "#66BB6A", "#90A4AE", "#0D47A1"];
     return colors[n % colors.length];
 }
@@ -94,12 +94,12 @@ d3.json("./incidents/general_incidents.json", function (error, data) {
                     //populate incident
                     d3.select("#incident p")
                         .html("<h4 class=\"f4 center mw6\">" + data[picked].title + "</h4>" + "<div id=\"play-area\"> <ol id =\"choices\"><ol></div>");
-                    container.on("click", spin, stopwatch.reset(), stopwatch.start(), changeControls(), loadStory(data[picked].inkstory));
+                    container.on("click", spin, stopwatch.reset(), stopwatch.start(), changeControls(), loadStory(data[picked].inkstory), restart());
                    } else {
                     //populate incident
                     d3.select("#incident p")
                         .html("<h4 class=\"f4 center mw6\">" + data[picked].title + "</h4>" + data[picked].scenario);
-                    container.on("click", spin, stopwatch.reset(), stopwatch.start(), changeControls());
+                    container.on("click", spin, stopwatch.reset(), stopwatch.start(), changeControls(), restart());
                 }
                 oldrotation = rotation;
             });


### PR DESCRIPTION
Ensured that the actions become unchecked when spinning the wheel again. This is also done when resetting the timer, since it seemed logical to reset progress when restarting the timer.